### PR TITLE
Fix & improve Lucas-Kanade optical flow

### DIFF
--- a/src/ImageTracking.jl
+++ b/src/ImageTracking.jl
@@ -26,30 +26,29 @@ include("haar.jl")
 include("utility.jl")
 
 export
-
-	# main functions
+    # main functions
     optical_flow,
     optical_flow!,
 
-	# other functions
-	haar_coordinates,
-	haar_features,
+    # other functions
+    haar_coordinates,
+    haar_features,
 
-	# other functions
-	ColorBased,
-	EndpointError,
-	AngularError,
-	polynomial_expansion,
-	RasterConvention,
-	CartesianConvention,
-	visualize_flow,
-	read_flow_file,
-	evaluate_flow_error,
-	calculate_statistics,
+    # other functions
+    ColorBased,
+    EndpointError,
+    AngularError,
+    polynomial_expansion,
+    RasterConvention,
+    CartesianConvention,
+    visualize_flow,
+    read_flow_file,
+    evaluate_flow_error,
+    calculate_statistics,
 
-	# optical flow algorithms
-	LucasKanade,
-	Farneback,
+    # optical flow algorithms
+    LucasKanade,
+    Farneback,
 
     # types that select implementation
     ConvolutionImplementation,

--- a/src/ImageTracking.jl
+++ b/src/ImageTracking.jl
@@ -54,6 +54,4 @@ export
     ConvolutionImplementation,
     MatrixImplementation
 
-
-
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -2,7 +2,7 @@
 # Reference:
 # Blinn, J. (1996). Consider the lowly 2 x 2 matrix. IEEE Computer Graphics and Applications, 16(2), 82-88.
 # https://scicomp.stackexchange.com/questions/8899/robust-algorithm-for-2-times-2-svd
-function svd2x2(M::AbstractArray)
+function svd2x2(M::AbstractMatrix{T}) where T <: Number
     E = (M[1,1] + M[2,2]) / 2
     F = (M[1,1] - M[2,2]) / 2
     G = (M[2,1] + M[1,2]) / 2
@@ -16,17 +16,30 @@ function svd2x2(M::AbstractArray)
     θ = (a₂ - a₁) / 2
     ϕ = (a₂ + a₁) / 2
     s = sign(sy)
-    U = SMatrix{2,2,Float64}(cos(ϕ), sin(ϕ), -s*sin(ϕ), s*cos(ϕ))
-    S = SMatrix{2,2,Float64}(sx, 0.0, 0.0, abs(sy))
-    V = SMatrix{2,2,Float64}(cos(θ), -sin(θ), sin(θ), cos(θ))
-    U,S,V
+
+    sinϕ, cosϕ = sin(ϕ), cos(ϕ)
+    sinθ, cosθ = sin(θ), cos(θ)
+
+    U = SMatrix{2, 2, T}(cosϕ, sinϕ, -s * sinϕ, s * cosϕ)
+    S = SMatrix{2, 2, T}(sx, 0.0, 0.0, abs(sy))
+    V = SMatrix{2, 2, T}(cosθ, -sinθ, sinθ, cosθ)
+    U, S, V
 end
 
-#  Computes the Moore-Penrose pseudoinverse for a 2-by-2 matrix M by only inverting
-#  singular values above the threshold `tol = sqrt(eps(real(float(one(eltype(M))))))`
-function pinv2x2(M::AbstractArray)
-     tol = sqrt(eps(real(float(one(eltype(M))))))
-     U,S,V = svd2x2(M)
-     D = SMatrix{2,2,Float64}( S[1,1] > tol ?  1/S[1,1] : 0.0 , 0.0, 0.0, S[2,2] > tol ?  1/S[2,2] : 0.0 )
-     U*D*V'
+# Computes the Moore-Penrose pseudoinverse for a 2-by-2 matrix M by only inverting
+# singular values above the threshold `tol = sqrt(eps(real(float(one(eltype(M))))))`
+function pinv2x2(M)
+    U, S, V = M |> svd2x2
+    pinv2x2(U, S, V)
+end
+
+function pinv2x2(
+    U::AbstractMatrix{T}, S::AbstractMatrix{T}, V::AbstractMatrix{T},
+) where T <: Number
+    tol = √eps(T |> one |> float |> real)
+    D = SMatrix{2, 2, T}(
+        S[1, 1] > tol ? (1.0 / S[1, 1]) : 0.0, 0.0, 0.0,
+        S[2, 2] > tol ? (1.0 / S[2, 2]) : 0.0,
+    )
+    U * D * V'
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -29,14 +29,14 @@ end
 # Computes the Moore-Penrose pseudoinverse for a 2-by-2 matrix M by only inverting
 # singular values above the threshold `tol = sqrt(eps(real(float(one(eltype(M))))))`
 function pinv2x2(M)
-    U, S, V = M |> svd2x2
+    U, S, V = svd2x2(M)
     pinv2x2(U, S, V)
 end
 
 function pinv2x2(
     U::AbstractMatrix{T}, S::AbstractMatrix{T}, V::AbstractMatrix{T},
 ) where T <: Number
-    tol = √eps(T |> one |> float |> real)
+    tol = √eps(real(float(one(T))))
     D = SMatrix{2, 2, T}(
         S[1, 1] > tol ? (1.0 / S[1, 1]) : 0.0, 0.0, 0.0,
         S[2, 2] > tol ? (1.0 / S[2, 2]) : 0.0,

--- a/src/lucas_kanade.jl
+++ b/src/lucas_kanade.jl
@@ -150,20 +150,22 @@ function optflow!(
 end
 
 function compute_partial_derivatives(Iy, Ix; σ = 4)
-    kernel = Kernel.gaussian(σ)
+    kernel = KernelFactors.gaussian(σ)
+    kernel_factors = kernelfactors((kernel, kernel))
+
     squared = typeof(Iy)(undef, size(Iy))
     filtered = typeof(Iy)(undef, size(Iy))
 
     squared .= Iy .* Iy
-    imfilter!(filtered, squared, kernel)
+    imfilter!(filtered, squared, kernel_factors)
     Iyy_integral_table = integral_image(filtered)
 
     squared .= Ix .* Ix
-    imfilter!(filtered, squared, kernel)
+    imfilter!(filtered, squared, kernel_factors)
     Ixx_integral_table = integral_image(filtered)
 
     squared .= Iy .* Ix
-    imfilter!(filtered, squared, kernel)
+    imfilter!(filtered, squared, kernel_factors)
     Iyx_integral_table = integral_image(filtered)
 
     Iyy_integral_table, Ixx_integral_table, Iyx_integral_table

--- a/src/lucas_kanade.jl
+++ b/src/lucas_kanade.jl
@@ -1,108 +1,143 @@
-
-
 function optflow(first_img::AbstractArray{T, 2}, second_img::AbstractArray{T,2}, points::Array{SVector{2, Float64}, 1},  algorithm::LucasKanade) where T <: Gray
     displacement = Array{SVector{2, Float64}, 1}(undef, length(points))
     for i in eachindex(displacement)
-            displacement[i] = SVector{2, Float64}(0.0, 0.0)
+        displacement[i] = SVector{2, Float64}(0.0, 0.0)
     end
     optflow!(first_img, second_img, points, displacement,  algorithm)
 end
 
-function optflow!(first_img::AbstractArray{T, 2}, second_img::AbstractArray{T,2}, points::Array{SVector{2, Float64}, 1}, displacement::Array{SVector{2, Float64}, 1}, algorithm::LucasKanade) where T <: Gray
-
-    # Convert (row, col) convention to (x,y) coordinate convention.
-    points = map(x -> SVector(last(x), first(x)), points)
-    map!(x -> SVector(last(x), first(x)), displacement, displacement)
-
+function optflow!(
+    first_img::AbstractArray{T, 2}, second_img::AbstractArray{T,2},
+    points::Array{SVector{2, Float64}, 1},
+    displacement::Array{SVector{2, Float64}, 1}, algorithm::LucasKanade,
+) where T <: Gray
     # Replace NaN with zero in both images.
     first_img = map(x -> isnan(x) ? zero(x) : x, first_img)
     second_img = map(x -> isnan(x) ? zero(x) : x, second_img)
 
     # Construct Gaussian pyramids for both the images.
-    first_pyramid, second_pyramid =  construct_pyramids(first_img, second_img,  algorithm.pyramid_levels)
+    first_pyramid, second_pyramid = construct_pyramids(
+        first_img, second_img, algorithm.pyramid_levels,
+    )
     flow, status, reliability = initialise_arrays(length(displacement))
 
-    for i = algorithm.pyramid_levels+1:-1:1
+    for i = (algorithm.pyramid_levels + 1):-1:1
+        @info "Pyramid level $i"
         # Extrapolate the second image so as to get intensity at non-integral points.
         itp = interpolate(second_pyramid[i], BSpline(Linear()))
         etp = extrapolate(itp, zero(eltype(second_pyramid[i])))
+        Iy, Ix = imgradients(
+            first_pyramid[i], KernelFactors.scharr,
+            Fill(zero(eltype(first_pyramid[i]))),
+        )
 
-        Ix, Iy = imgradients(first_pyramid[i], KernelFactors.scharr, Fill(zero(eltype(first_pyramid[i])))) # TODO: Fix row,col vs x,y convention
         # Calculate Ixx, Iyy and Ixy taking Gaussian weights for pixels in the grid.
         # Return integral tables to facilitate fast sums over regions in Ixx, Iyy and Ixy.
-        Ixx_integral_table, Ixy_integral_table, Iyy_integral_table =  compute_partial_derivatives(Ix, Iy)
+        Iyy_integral_table, Ixx_integral_table, Iyx_integral_table = compute_partial_derivatives(Iy, Ix)
 
-        inner_bounds = map(i -> first(i) +  algorithm.window_size:last(i) -  algorithm.window_size, axes(first_pyramid[i]))
+        # (Y, X) format.
+        inner_bounds = map(
+            i -> first(i) + algorithm.window_size:last(i) - algorithm.window_size,
+            axes(first_pyramid[i]),
+        )
         # Running the algorithm for each input point.
+        @info "Points", length(displacement)
         for j = 1:length(displacement)
-            if status[j]
-                # Position of the point in the current pyramid level.
-                point = determine_pyramid_coordinates(points, i, j)
-                # If the window falls inside the first image we pre-compute the
-                # spatial gradient matrix because in many instance the window
-                # will also be completely contained inside the second image.  If
-                # it turns out that the  corresponding window is not totally
-                # contained inside the second window then we will recompute the
-                # spatial gradient matrix again later.
-                if lies_in(inner_bounds, point)
-                    square_grid = SVector{2}(point[1] -  algorithm.window_size:point[1] +  algorithm.window_size, point[2] -  algorithm.window_size:point[2] +  algorithm.window_size)
-                    G = compute_spatial_gradient(square_grid, Ixx_integral_table, Ixy_integral_table, Iyy_integral_table)
-                end
+            !status[j] && continue
 
-                pyramid_contribution = SVector{2}(0.0,0.0)
-                for k = 1:algorithm.iterations
-                    putative_flow = displacement[j] + pyramid_contribution
-                    putative_correspondence = point + putative_flow
-                    if lies_in(axes(second_img), putative_correspondence)
-                        grid, offsets, is_truncated_window = get_grid(first_pyramid[i], point, putative_flow, algorithm.window_size)
-                        # If the grid is not a square then we cannot reuse our precomputed spatial gradient.
-                        if is_truncated_window
-                            G = compute_spatial_gradient(grid, Ixx_integral_table, Ixy_integral_table, Iyy_integral_table)
-                        end
-                        A = @inbounds view(first_pyramid[i], grid[1], grid[2])
-                        Ix_window = @inbounds view(Ix, grid[1], grid[2])
-                        Iy_window = @inbounds view(Iy, grid[1], grid[2])
-                        estimated_flow = compute_flow_vector(point + putative_flow, G, A, Ix_window, Iy_window, grid, offsets, etp)
+            # Position of the point in the current pyramid level.
+            point = determine_pyramid_coordinates(points, i, j)
+            @info "$j | Point $point"
+            # If the window falls inside the first image we pre-compute the
+            # spatial gradient matrix because in many instance the window
+            # will also be completely contained inside the second image.  If
+            # it turns out that the  corresponding window is not totally
+            # contained inside the second window then we will recompute the
+            # spatial gradient matrix again later.
+            if lies_in(inner_bounds, point)
+                square_grid = SVector{2}(
+                    (point[1] - algorithm.window_size):(point[1] + algorithm.window_size),
+                    (point[2] - algorithm.window_size):(point[2] + algorithm.window_size),
+                )
+                G = compute_spatial_gradient(
+                    square_grid,
+                    Iyy_integral_table,
+                    Iyx_integral_table,
+                    Ixx_integral_table,
+                )
+            end
 
-                        pyramid_contribution += estimated_flow
-                        # Minimum eigenvalue in the matrix is used as a measure of reliability.
-                        F =  eigen(G)
-                        min_eigenvalue = F.values[1] < F.values[2] ? F.values[1] : F.values[2]
-                        grid_size = prod(length.(grid))
-                        reliability[j] = min_eigenvalue / grid_size
-
-                        # If the point is too unreliable then it should be declared lost.
-                        if is_lost(first_pyramid[i], point + pyramid_contribution, min_eigenvalue, algorithm.eigenvalue_threshold, grid_size)
-                            declare_lost!(status, flow, j)
-                            break
-                        end
-                    else
-                        # In this instance the corresponding point lies outside of the second image so we declare it as lost.
-                        declare_lost!(status, flow, j)
-                        break
-                    end
-                end
-
-                # If the optical flow is too large then the point should be declared lost.
-                if is_lost(SVector(displacement[j]), 2* algorithm.window_size)
+            pyramid_contribution = SVector{2}(0.0, 0.0)
+            for k = 1:algorithm.iterations
+                putative_flow = displacement[j] + pyramid_contribution
+                putative_correspondence = point + putative_flow
+                if !lies_in(axes(second_img), putative_correspondence)
                     declare_lost!(status, flow, j)
+                    break
                 end
 
-                if status[j]
-                    flow[j] = pyramid_contribution
-                    # A guess for the next level of the pyramid.
-                    displacement[j] = 2*(displacement[j] + flow[j])
+                grid, offsets, is_truncated_window = get_grid(
+                    first_pyramid[i], point, putative_flow,
+                    algorithm.window_size,
+                )
+                if is_truncated_window
+                    G = compute_spatial_gradient(
+                        grid,
+                        Iyy_integral_table,
+                        Iyx_integral_table,
+                        Ixx_integral_table,
+                    )
                 end
+                @info "IT $k | G", G
+
+                A = view(first_pyramid[i], grid[1], grid[2])
+                Ix_window = view(Ix, grid[1], grid[2])
+                Iy_window = view(Iy, grid[1], grid[2])
+
+                estimated_flow = compute_flow_vector(
+                    putative_correspondence, G, A,
+                    Iy_window, Ix_window, offsets, etp,
+                )
+                # TODO Add epsilon termination criteria.
+                pyramid_contribution += estimated_flow
+                @info "It $k | Point $j | Pyramid contribution $pyramid_contribution | Estimated Flow $estimated_flow"
+
+                # Minimum eigenvalue in the matrix is used as a measure of reliability.
+                F = eigen(G)
+                min_eigenvalue = F.values[1] < F.values[2] ? F.values[1] : F.values[2]
+                grid_size = prod(length.(grid))
+                reliability[j] = min_eigenvalue / grid_size
+
+                # If the point is too unreliable then it should be declared lost.
+                if is_lost(
+                    first_pyramid[i], point + pyramid_contribution,
+                    min_eigenvalue, algorithm.eigenvalue_threshold, grid_size,
+                )
+                    @info "[x] Point $j is too unrealiable."
+                    declare_lost!(status, flow, j)
+                    break
+                end
+            end
+
+            # If the optical flow is too large then the point should be declared lost.
+            if status[j] && is_lost(displacement[j], 2 * algorithm.window_size)
+                @info "[x] Point $j flow is flow too big"
+                declare_lost!(status, flow, j)
+            end
+
+            if status[j]
+                flow[j] = pyramid_contribution
+                # A guess for the next level of the pyramid.
+                displacement[j] = 2 * (displacement[j] + flow[j])
+                @info "$j | Point $point | Displacement $(displacement[j])"
             end
         end
     end
 
     # Final optical flow.
-    output_flow = 0.5*displacement
+    output_flow = 0.5 * displacement
     return output_flow, status
 end
-
-
 
 function declare_lost!(status, flow, j)
     status[j] = false
@@ -125,61 +160,85 @@ function initialise_arrays(N::Int)
     return flow, status, reliability
 end
 
-function compute_partial_derivatives(Ix, Iy)
-    Ixx = imfilter(Ix.*Ix, Kernel.gaussian(4))
-    Iyy = imfilter(Iy.*Iy, Kernel.gaussian(4))
-    Ixy = imfilter(Ix.*Iy, Kernel.gaussian(4))
+function compute_partial_derivatives(Iy, Ix)
+    Iyy = imfilter(Iy .* Iy, Kernel.gaussian(1))
+    Ixx = imfilter(Ix .* Ix, Kernel.gaussian(1))
+    Iyx = imfilter(Iy .* Ix, Kernel.gaussian(1))
 
-    Ixx_integral_table = integral_image(Ixx)
-    Ixy_integral_table = integral_image(Ixy)
     Iyy_integral_table = integral_image(Iyy)
-    return Ixx_integral_table, Ixy_integral_table, Iyy_integral_table
-end
-
-
-function compute_flow_vector(corresponding_point, G, A, Ix, Iy, grid, offsets, etp)
-    # Solve a linear system of equations in order to determine the flow vector.
-    bk = prepare_linear_system(corresponding_point, A, Ix, Iy, grid, offsets, etp)
-    G_inv = pinv2x2(G) #TODO: Add the pinv2x2 method to the StaticArrays package.
-    ηk = G_inv*bk
+    Ixx_integral_table = integral_image(Ixx)
+    Iyx_integral_table = integral_image(Iyx)
+    return Iyy_integral_table, Ixx_integral_table, Iyx_integral_table
 end
 
 function determine_pyramid_coordinates(points, i, j)
-    px = floor(Int,(points[j][1]) / 2^i)
-    py = floor(Int,(points[j][2]) / 2^i)
+    # TODO i - 1 is correct? Test with pyramids.
+    px = floor(Int, points[j][1] / 2 ^ (i - 1))
+    py = floor(Int, points[j][2] / 2 ^ (i - 1))
     point = SVector{2}(px ,py)
 end
 
-function compute_spatial_gradient(grid, Ixx_integral::AbstractArray, Ixy_integral::AbstractArray, Iyy_integral::AbstractArray)
-    sum_Ixx = boxdiff(Ixx_integral, grid[1], grid[2])
-    sum_Ixy = boxdiff(Ixy_integral, grid[1], grid[2])
+"""
+grid in (Y, X) format.
+"""
+function compute_spatial_gradient(
+    grid, Iyy_integral, Iyx_integral, Ixx_integral,
+)
     sum_Iyy = boxdiff(Iyy_integral, grid[1], grid[2])
-    # Spatial gradient matrix.
-    G = SMatrix{2,2,Float64}(sum_Ixx ,sum_Ixy, sum_Ixy, sum_Iyy)
+    sum_Ixx = boxdiff(Ixx_integral, grid[1], grid[2])
+    sum_Iyx = boxdiff(Iyx_integral, grid[1], grid[2])
+    SMatrix{2, 2, Float64}(sum_Iyy, sum_Iyx, sum_Iyx, sum_Ixx)
 end
 
+"""
+Evaluate Σ(δI .* I_y) and Σ(δI .* I_x), where δI = A .- B
 
-function prepare_linear_system(corresponding_point, A, Ix, Iy, grid, offsets, etp)
-    bx = 0.0
-    by = 0.0
+B - is the extrapolated (for subpixel precision) second image pyramid layer.
+δI = A - B - is the temporal image derivative at the point [x, y].
+
+b = Σ_y Σ_x [δI * Iy, δI * Ix]
+"""
+function prepare_linear_system(corresponding_point, A, Iy, Ix, offsets, B)
+    by, bx = 0.0, 0.0
     P, Q = size(A)
-    # Evaluates sum(δI.*I_x) and sum(δI.*I_y), where δI = A .- B
-    @inbounds begin
-        for q = 1:Q
-           for p = 1:P
-                Apq = A[p,q]
-                r = corresponding_point[1] + offsets[1][p]
-                c = corresponding_point[2] + offsets[2][q]
-                Bpq = etp(r, c) # Subpixel precision
-                bx = bx + (Apq - Bpq)*Ix[p,q]
-                by = by + (Apq - Bpq)*Iy[p,q]
-            end
-        end
+
+    save("/home/pxl-th/B.png", B)
+
+    for q = 1:Q, p = 1:P
+        r = corresponding_point[1] + offsets[1][p]
+        c = corresponding_point[2] + offsets[2][q]
+
+        # TODO debug, visualize B
+        δI = A[p, q] - B(r, c)
+        @info "A $(A[p, q]), B $(B(r, c)), A - B $(δI)"
+        by += δI * Iy[p, q]
+        bx += δI * Ix[p, q]
     end
-    b = SVector{2}(bx, by)
+
+    # TODO b vector should decrease with the iterations.
+    b = SVector{2}(by, bx)
+    @info "B", b
+    b
 end
 
-function in_image(img::AbstractArray{T, 2}, point::SVector{2, U}, window::Int) where {T <: Gray, U <: Union{Int, Float64}}
+function compute_flow_vector(
+    corresponding_point, G, pyramid_window,
+    Ix, Iy, offsets, etp,
+)
+    # Solve a linear system of equations in order to determine the flow vector.
+    b = prepare_linear_system(
+        corresponding_point, pyramid_window,
+        Iy, Ix,
+        offsets, etp,
+    )
+    G_inv = pinv(G)
+    # G_inv = pinv2x2(G)
+    G_inv * b
+end
+
+function in_image(
+    img::AbstractArray{T, 2}, point::SVector{2, U}, window::Int,
+) where {T <: Gray, U <: Union{Int, Float64}}
     first_axis = first(axes(img))
     second_axis = last(axes(img))
     if point[1] < first(first_axis) || point[2] < first(second_axis) || point[1] > last(first_axis) || point[2] > last(second_axis)
@@ -189,71 +248,63 @@ function in_image(img::AbstractArray{T, 2}, point::SVector{2, U}, window::Int) w
     end
 end
 
-function is_lost(img::AbstractArray{T, 2}, point::SVector{2, U}, min_eigenvalue::Float64, eigenvalue_threshold::Float64, window::Int) where {T <: Gray, U <: Union{Int, Float64}}
-    if !(in_image(img, point, window))
-        return true
-    else
-        val = min_eigenvalue/window
+function is_lost(
+    img::AbstractArray{T, 2}, point::SVector{2, U}, min_eigenvalue::Float64,
+    eigenvalue_threshold::Float64, window::Int,
+) where {T <: Gray, U <: Union{Int, Float64}}
+    !(in_image(img, point, window)) && return true
 
-        if val < eigenvalue_threshold
-            return true
-        else
-            return false
-        end
-    end
+    val = min_eigenvalue / window
+    val < eigenvalue_threshold
 end
 
 function is_lost(point::SVector{2, Float64}, window_size::Int)
-    if point[1] > window_size || point[2] > window_size
-        return true
-    else
-        return false
-    end
+    point[1] > window_size || point[2] > window_size
 end
 
-function lies_in(area::Tuple{AbstractRange{Int},AbstractRange{Int}}, point::SVector{2, T}) where T <: Union{Int,Float64}
-    if first(area[1]) <= point[1] && last(area[1]) >= point[1] && first(area[2]) <= point[2] && last(area[2]) >= point[2]
-        return true
-    else
-        return false
-    end
+function lies_in(
+    area::Tuple{AbstractRange{Int}, AbstractRange{Int}}, point::SVector{2, T},
+) where T <: Union{Int,Float64}
+    first(area[1]) ≤ point[1] ≤ last(area[1]) &&
+    first(area[2]) ≤ point[2] ≤ last(area[2])
 end
 
-function get_grid(img::AbstractArray{T, 2}, point::SVector{2, U}, displacement::SVector{2, Float64}, window_size::Int) where {T <: Gray, U <: Union{Int, Float64}}
-    first_axis, second_axis = axes(img)
-    allowed_area = map(i -> first(i) + window_size:last(i) - window_size, axes(img))
+function get_grid(
+    img::AbstractArray{T, 2},
+    point::SVector{2, U}, displacement::SVector{2, Float64},
+    window_size::Int,
+) where {T <: Gray, U <: Union{Int, Float64}}
     new_point = point + displacement
+    allowed_area = map(
+        i -> (first(i) + window_size):(last(i) - window_size), axes(img),
+    )
+    is_truncated_window = (
+        !lies_in(allowed_area, new_point) || !lies_in(allowed_area, point)
+    )
+    # @info "Allowed area", allowed_area
+    # @info "Point", point, "New point", new_point
 
-    if !lies_in(allowed_area, new_point) || !lies_in(allowed_area, point)
-        is_truncated_window = true
-    else
-        is_truncated_window = false
-    end
+    first_axis, second_axis = axes(img)
 
-    # TODO: Convert these loops to explicit formulae.
-    w_up = 0
-    while point[1] - (w_up + 1) > first(first_axis)  && new_point[1] - (w_up + 1) >  first(first_axis)  &&  (w_up + 1) < window_size
-        w_up += 1
-    end
+    w_up = floor(Int64, min(window_size, min(
+        point[1] - first(first_axis), new_point[1] - first(second_axis),
+    )))
+    w_down = floor(Int64, min(window_size, min(
+        last(first_axis) - point[1], last(second_axis) - new_point[1],
+    )))
+    w_left = floor(Int64, min(window_size, min(
+        point[2] - first(second_axis), new_point[2] - first(second_axis),
+    )))
+    w_right = floor(Int64, min(window_size, min(
+        last(second_axis) - point[2], last(second_axis) - new_point[2],
+    )))
 
-    w_down = 0
-    while point[1] + (w_down + 1)  < last(first_axis)  && new_point[1] + (w_down + 1) <  last(first_axis)  && (w_down + 1) < window_size
-        w_down += 1
-    end
-
-    w_left = 0
-    while point[2] - (w_left + 1) > first(second_axis) && new_point[2] - (w_left + 1) >  first(second_axis) && (w_left + 1) < window_size
-        w_left += 1
-    end
-
-    w_right = 0
-    while point[2] + (w_right + 1) < last(second_axis) && new_point[2] + (w_right + 1) >  last(second_axis) && (w_right + 1) < window_size
-        w_right += 1
-    end
-
-
-    grid_1 = (point[1] - w_up:point[1] + w_down, point[2] - w_left:point[2] + w_right)
+    # (Y, X) format.
+    new_grid = (
+        (point[1] - w_up):(point[1] + w_down),
+        (point[2] - w_left):(point[2] + w_right),
+    )
     offsets = (UnitRange(-w_up, w_down), UnitRange(-w_left, w_right))
-
-    return grid_1, offsets, is_truncated_window
+    # @info "New grid $new_grid | Offsets $offsets"
+    return new_grid, offsets, is_truncated_window
 end

--- a/src/lucas_kanade.jl
+++ b/src/lucas_kanade.jl
@@ -122,7 +122,8 @@ function optflow!(
                 )
                 pyramid_contribution += estimated_flow
                 # Epsilon termination criteria.
-                norm(estimated_flow) < algorithm.ϵ && break
+                abs(estimated_flow[1]) < algorithm.ϵ &&
+                    abs(estimated_flow[2]) < algorithm.ϵ && break
                 # Check if tracked point is out of image bounds.
                 if !lies_in(level_resolution, point + pyramid_contribution)
                     @inbounds status[did] = false

--- a/src/lucas_kanade.jl
+++ b/src/lucas_kanade.jl
@@ -121,14 +121,14 @@ function optflow!(
                     grid, offsets, G_inv,
                 )
                 pyramid_contribution += estimated_flow
-                # Epsilon termination criteria.
-                abs(estimated_flow[1]) < algorithm.ϵ &&
-                    abs(estimated_flow[2]) < algorithm.ϵ && break
                 # Check if tracked point is out of image bounds.
                 if !lies_in(level_resolution, point + pyramid_contribution)
                     @inbounds status[did] = false
                     break
                 end
+                # Epsilon termination criteria.
+                abs(estimated_flow[1]) < algorithm.ϵ &&
+                    abs(estimated_flow[2]) < algorithm.ϵ && break
             end
             @inbounds begin
             # Check if flow is too big.

--- a/src/lucas_kanade.jl
+++ b/src/lucas_kanade.jl
@@ -1,9 +1,12 @@
-function optflow(first_img::AbstractArray{T, 2}, second_img::AbstractArray{T,2}, points::Array{SVector{2, Float64}, 1},  algorithm::LucasKanade) where T <: Gray
-    displacement = Array{SVector{2, Float64}, 1}(undef, length(points))
-    for i in eachindex(displacement)
-        displacement[i] = SVector{2, Float64}(0.0, 0.0)
-    end
-    optflow!(first_img, second_img, points, displacement,  algorithm)
+# TODO allow passing precomputed pyramids.
+# TODO add epsilon termination criteria.
+
+function optflow(
+    first_img::AbstractArray{T, 2}, second_img::AbstractArray{T,2},
+    points::Array{SVector{2, Float64}, 1}, algorithm::LucasKanade,
+) where T <: Gray
+    displacement = fill(SVector{2, Float64}(0.0, 0.0), length(points))
+    optflow!(first_img, second_img, points, displacement, algorithm)
 end
 
 function optflow!(
@@ -11,19 +14,17 @@ function optflow!(
     points::Array{SVector{2, Float64}, 1},
     displacement::Array{SVector{2, Float64}, 1}, algorithm::LucasKanade,
 ) where T <: Gray
-    # Replace NaN with zero in both images.
+    window = algorithm.window_size
     first_img = map(x -> isnan(x) ? zero(x) : x, first_img)
     second_img = map(x -> isnan(x) ? zero(x) : x, second_img)
 
-    # Construct Gaussian pyramids for both the images.
     first_pyramid, second_pyramid = construct_pyramids(
         first_img, second_img, algorithm.pyramid_levels,
     )
-    flow, status, reliability = initialise_arrays(length(displacement))
+    flow = fill(SVector{2, Float64}(0.0, 0.0), length(displacement))
+    status = trues(length(displacement))
 
     for i = (algorithm.pyramid_levels + 1):-1:1
-        @info "Pyramid level $i"
-        # Extrapolate the second image so as to get intensity at non-integral points.
         itp = interpolate(second_pyramid[i], BSpline(Linear()))
         etp = extrapolate(itp, zero(eltype(second_pyramid[i])))
         Iy, Ix = imgradients(
@@ -31,40 +32,26 @@ function optflow!(
             Fill(zero(eltype(first_pyramid[i]))),
         )
 
-        # Calculate Ixx, Iyy and Ixy taking Gaussian weights for pixels in the grid.
-        # Return integral tables to facilitate fast sums over regions in Ixx, Iyy and Ixy.
-        Iyy_integral_table, Ixx_integral_table, Iyx_integral_table = compute_partial_derivatives(Iy, Ix)
+        Iyy_it, Ixx_it, Iyx_it = compute_partial_derivatives(Iy, Ix)
 
-        # (Y, X) format.
         inner_bounds = map(
-            i -> first(i) + algorithm.window_size:last(i) - algorithm.window_size,
-            axes(first_pyramid[i]),
+            i -> first(i) + window:last(i) - window, axes(first_pyramid[i]),
         )
-        # Running the algorithm for each input point.
-        @info "Points", length(displacement)
+
         for j = 1:length(displacement)
             !status[j] && continue
 
-            # Position of the point in the current pyramid level.
-            point = determine_pyramid_coordinates(points, i, j)
-            @info "$j | Point $point"
-            # If the window falls inside the first image we pre-compute the
-            # spatial gradient matrix because in many instance the window
-            # will also be completely contained inside the second image.  If
-            # it turns out that the  corresponding window is not totally
-            # contained inside the second window then we will recompute the
-            # spatial gradient matrix again later.
+            point = get_pyramid_coordinates(points, i, j)
+
             if lies_in(inner_bounds, point)
-                square_grid = SVector{2}(
-                    (point[1] - algorithm.window_size):(point[1] + algorithm.window_size),
-                    (point[2] - algorithm.window_size):(point[2] + algorithm.window_size),
+                grid = SVector{2}(
+                    (point[1] - window):(point[1] + window),
+                    (point[2] - window):(point[2] + window),
                 )
-                G = compute_spatial_gradient(
-                    square_grid,
-                    Iyy_integral_table,
-                    Iyx_integral_table,
-                    Ixx_integral_table,
-                )
+                G = compute_spatial_gradient(grid, Iyy_it, Iyx_it, Ixx_it)
+                G_inv = G |> pinv
+                min_eigenvalue = (G |> eigen).values |> minimum
+                min_eigenvalue /= grid .|> length |> prod
             end
 
             pyramid_contribution = SVector{2}(0.0, 0.0)
@@ -78,86 +65,59 @@ function optflow!(
 
                 grid, offsets, is_truncated_window = get_grid(
                     first_pyramid[i], point, putative_flow,
-                    algorithm.window_size,
+                    window,
                 )
                 if is_truncated_window
-                    G = compute_spatial_gradient(
-                        grid,
-                        Iyy_integral_table,
-                        Iyx_integral_table,
-                        Ixx_integral_table,
-                    )
+                    G = compute_spatial_gradient(grid, Iyy_it, Iyx_it, Ixx_it)
+                    G_inv = G |> pinv
+                    min_eigenvalue = (G |> eigen).values |> minimum
+                    min_eigenvalue /= grid .|> length |> prod
                 end
-                @info "IT $k | G", G
 
                 A = view(first_pyramid[i], grid[1], grid[2])
                 Ix_window = view(Ix, grid[1], grid[2])
                 Iy_window = view(Iy, grid[1], grid[2])
 
+                # TODO Add epsilon termination criteria.
                 estimated_flow = compute_flow_vector(
-                    putative_correspondence, G, A,
+                    putative_correspondence, G_inv, A,
                     Iy_window, Ix_window, offsets, etp,
                 )
-                # TODO Add epsilon termination criteria.
                 pyramid_contribution += estimated_flow
-                @info "It $k | Point $j | Pyramid contribution $pyramid_contribution | Estimated Flow $estimated_flow"
 
-                # Minimum eigenvalue in the matrix is used as a measure of reliability.
-                F = eigen(G)
-                min_eigenvalue = F.values[1] < F.values[2] ? F.values[1] : F.values[2]
-                grid_size = prod(length.(grid))
-                reliability[j] = min_eigenvalue / grid_size
-
-                # If the point is too unreliable then it should be declared lost.
                 if is_lost(
                     first_pyramid[i], point + pyramid_contribution,
-                    min_eigenvalue, algorithm.eigenvalue_threshold, grid_size,
+                    min_eigenvalue, algorithm.eigenvalue_threshold,
                 )
-                    @info "[x] Point $j is too unrealiable."
                     declare_lost!(status, flow, j)
                     break
                 end
             end
 
-            # If the optical flow is too large then the point should be declared lost.
-            if status[j] && is_lost(displacement[j], 2 * algorithm.window_size)
-                @info "[x] Point $j flow is flow too big"
+            if status[j] && is_lost(displacement[j], 2 * window)
                 declare_lost!(status, flow, j)
             end
 
             if status[j]
                 flow[j] = pyramid_contribution
-                # A guess for the next level of the pyramid.
                 displacement[j] = 2 * (displacement[j] + flow[j])
-                @info "$j | Point $point | Displacement $(displacement[j])"
             end
         end
     end
 
-    # Final optical flow.
     output_flow = 0.5 * displacement
-    return output_flow, status
+    output_flow, status
 end
 
 function declare_lost!(status, flow, j)
     status[j] = false
-    flow[j] = SVector{2}(0.0,0.0)
+    flow[j] = SVector{2, Float64}(0.0, 0.0)
 end
 
 function construct_pyramids(first_img, second_img, pyramid_levels)
     first_pyramid = gaussian_pyramid(first_img, pyramid_levels, 2, 1.0)
     second_pyramid = gaussian_pyramid(second_img, pyramid_levels, 2, 1.0)
-    return first_pyramid, second_pyramid
-end
-
-function initialise_arrays(N::Int)
-    flow = Array{SVector{2, Float64}, 1}(undef, N)
-    for i in eachindex(flow)
-        flow[i] = SVector{2, Float64}(0.0, 0.0)
-    end
-    status = trues(N)
-    reliability = zeros(Float64, N)
-    return flow, status, reliability
+    first_pyramid, second_pyramid
 end
 
 function compute_partial_derivatives(Iy, Ix)
@@ -168,19 +128,16 @@ function compute_partial_derivatives(Iy, Ix)
     Iyy_integral_table = integral_image(Iyy)
     Ixx_integral_table = integral_image(Ixx)
     Iyx_integral_table = integral_image(Iyx)
-    return Iyy_integral_table, Ixx_integral_table, Iyx_integral_table
+
+    Iyy_integral_table, Ixx_integral_table, Iyx_integral_table
 end
 
-function determine_pyramid_coordinates(points, i, j)
-    # TODO i - 1 is correct? Test with pyramids.
+function get_pyramid_coordinates(points, i, j)
     px = floor(Int, points[j][1] / 2 ^ (i - 1))
     py = floor(Int, points[j][2] / 2 ^ (i - 1))
-    point = SVector{2}(px ,py)
+    SVector{2}(px ,py)
 end
 
-"""
-grid in (Y, X) format.
-"""
 function compute_spatial_gradient(
     grid, Iyy_integral, Iyx_integral, Ixx_integral,
 )
@@ -199,62 +156,38 @@ B - is the extrapolated (for subpixel precision) second image pyramid layer.
 b = Σ_y Σ_x [δI * Iy, δI * Ix]
 """
 function prepare_linear_system(corresponding_point, A, Iy, Ix, offsets, B)
-    by, bx = 0.0, 0.0
     P, Q = size(A)
 
-    save("/home/pxl-th/B.png", B)
-
-    for q = 1:Q, p = 1:P
+    b = SVector{2, Float64}(0.0, 0.0)
+    for q in 1:Q, p in 1:P
         r = corresponding_point[1] + offsets[1][p]
         c = corresponding_point[2] + offsets[2][q]
 
-        # TODO debug, visualize B
         δI = A[p, q] - B(r, c)
-        @info "A $(A[p, q]), B $(B(r, c)), A - B $(δI)"
-        by += δI * Iy[p, q]
-        bx += δI * Ix[p, q]
+        b += SVector{2, Float64}(δI * Iy[p, q], δI * Ix[p, q])
     end
-
-    # TODO b vector should decrease with the iterations.
-    b = SVector{2}(by, bx)
-    @info "B", b
     b
 end
 
 function compute_flow_vector(
-    corresponding_point, G, pyramid_window,
-    Ix, Iy, offsets, etp,
+    corresponding_point, G_inv, pyramid_window,
+    Iy, Ix, offsets, etp,
 )
-    # Solve a linear system of equations in order to determine the flow vector.
     b = prepare_linear_system(
         corresponding_point, pyramid_window,
         Iy, Ix,
         offsets, etp,
     )
-    G_inv = pinv(G)
-    # G_inv = pinv2x2(G)
     G_inv * b
 end
 
-function in_image(
-    img::AbstractArray{T, 2}, point::SVector{2, U}, window::Int,
-) where {T <: Gray, U <: Union{Int, Float64}}
-    first_axis = first(axes(img))
-    second_axis = last(axes(img))
-    if point[1] < first(first_axis) || point[2] < first(second_axis) || point[1] > last(first_axis) || point[2] > last(second_axis)
-        return false
-    else
-        return true
-    end
-end
-
 function is_lost(
-    img::AbstractArray{T, 2}, point::SVector{2, U}, min_eigenvalue::Float64,
-    eigenvalue_threshold::Float64, window::Int,
+    img::AbstractArray{T, 2}, point::SVector{2, U},
+    min_eigenvalue::Float64, eigenvalue_threshold::Float64,
 ) where {T <: Gray, U <: Union{Int, Float64}}
-    !(in_image(img, point, window)) && return true
+    !(lies_in(axes(img), point)) && return true
 
-    val = min_eigenvalue / window
+    val = min_eigenvalue
     val < eigenvalue_threshold
 end
 
@@ -281,8 +214,6 @@ function get_grid(
     is_truncated_window = (
         !lies_in(allowed_area, new_point) || !lies_in(allowed_area, point)
     )
-    # @info "Allowed area", allowed_area
-    # @info "Point", point, "New point", new_point
 
     first_axis, second_axis = axes(img)
 
@@ -299,12 +230,10 @@ function get_grid(
         last(second_axis) - point[2], last(second_axis) - new_point[2],
     )))
 
-    # (Y, X) format.
     new_grid = (
         (point[1] - w_up):(point[1] + w_down),
         (point[2] - w_left):(point[2] + w_right),
     )
     offsets = (UnitRange(-w_up, w_down), UnitRange(-w_left, w_right))
-    # @info "New grid $new_grid | Offsets $offsets"
-    return new_grid, offsets, is_truncated_window
+    new_grid, offsets, is_truncated_window
 end

--- a/src/optical_flow.jl
+++ b/src/optical_flow.jl
@@ -102,7 +102,12 @@ a default value of four is assumed.
 The algorithm calculates the minimum eigenvalue of a (2 x 2) normal matrix of
 optical flow equations, divided by number of pixels in a window; if this value
 is less than `eigenvalue_threshold`, then a corresponding feature is filtered
-out and its flow is not processed (default value is 10^-6).
+out and its flow is not processed (default value is 1e-4).
+
+## `ϵ` termination criteria
+
+Minimum required change in displacement at which the iterative algorithm continues to work.
+Default value is `1e-2`.
 
 ## References
 
@@ -114,12 +119,15 @@ struct LucasKanade{F <: Float64, I <: Int}  <: OpticalFlowAlgorithm
     window_size::I
     pyramid_levels::I
     eigenvalue_threshold::F
+    ϵ::Float64
 end
 
 LucasKanade(
     iterations::Int = 20; window_size::Int = 11, pyramid_levels::Int = 4,
-    eigenvalue_threshold::Real = 1e-4,
-) = LucasKanade(iterations, window_size,  pyramid_levels, eigenvalue_threshold)
+    eigenvalue_threshold::Real = 1e-4, ϵ = 1e-2,
+) = LucasKanade(
+    iterations, window_size,  pyramid_levels, eigenvalue_threshold, ϵ,
+)
 
 """
     flow = optical_flow(source, target, Farneback(Args...))

--- a/src/optical_flow.jl
+++ b/src/optical_flow.jl
@@ -123,11 +123,9 @@ struct LucasKanade{F <: Float64, I <: Int}  <: OpticalFlowAlgorithm
 end
 
 LucasKanade(
-    iterations::Int = 20; window_size::Int = 11, pyramid_levels::Int = 4,
-    eigenvalue_threshold::Real = 1e-4, ϵ = 1e-2,
-) = LucasKanade(
-    iterations, window_size,  pyramid_levels, eigenvalue_threshold, ϵ,
-)
+    iterations::Integer = 20; window_size::Integer = 11, pyramid_levels::Integer = 4,
+    eigenvalue_threshold::Real = 1e-4, ϵ::Real = 1e-2,
+) = LucasKanade(iterations, window_size,  pyramid_levels, eigenvalue_threshold, ϵ)
 
 """
     flow = optical_flow(source, target, Farneback(Args...))

--- a/src/optical_flow.jl
+++ b/src/optical_flow.jl
@@ -1,5 +1,5 @@
 """
-	OpticalFlowAlgorithm
+    OpticalFlowAlgorithm
 
 An optical flow algorithm with given parameters.
 """
@@ -110,17 +110,20 @@ out and its flow is not processed (default value is 10^-6).
 2. J.-Y. Bouguet, “Pyramidal implementation of the afﬁne lucas-kanade feature tracker description of the algorithm,” Intel Corporation, vol. 5,no. 1-10, p. 4, 2001.
 """
 struct LucasKanade{F <: Float64, I <: Int}  <: OpticalFlowAlgorithm
-	iterations::I
+    iterations::I
     window_size::I
     pyramid_levels::I
     eigenvalue_threshold::F
 end
 
-LucasKanade(iterations::Int = 20; window_size::Int = 11, pyramid_levels::Int = 4, eigenvalue_threshold::Real = 0.000001) = LucasKanade(iterations, window_size,  pyramid_levels, eigenvalue_threshold)
+LucasKanade(
+    iterations::Int = 20; window_size::Int = 11, pyramid_levels::Int = 4,
+    eigenvalue_threshold::Real = 1e-4,
+) = LucasKanade(iterations, window_size,  pyramid_levels, eigenvalue_threshold)
 
 """
-	flow = optical_flow(source, target, Farneback(Args...))
-	flow = optical_flow(source, target, displacement, Farneback(Args...))
+    flow = optical_flow(source, target, Farneback(Args...))
+    flow = optical_flow(source, target, displacement, Farneback(Args...))
 
 Returns the dense optical flow from the `source` to the `target` image using the `Farneback` algorithm.
 
@@ -135,21 +138,21 @@ The elements of `displacement` should represent the flow required to map the
 
 """
 function optical_flow(source::AbstractArray{T, 2}, target::AbstractArray{T,2}, algorithm::Farneback) where T <: Gray
-	# Sanity checks.
-	@assert size.(axes(source)) == size.(axes(target)) "Images must have the same size"
-	optflow(source, target, algorithm)
+    # Sanity checks.
+    @assert size.(axes(source)) == size.(axes(target)) "Images must have the same size"
+    optflow(source, target, algorithm)
 end
 
 function optical_flow(source::AbstractArray{T, 2}, target::AbstractArray{T,2}, displacement::Array{SVector{2, Float64}, 2}, algorithm::Farneback) where T <: Gray
-	# Sanity checks.
-	@assert size.(axes(source)) == size.(axes(target)) "Images must have the same size"
-	@assert size.(axes(source)) == size.(axes(displacement)) "Optical flow field must match image size"
-	optflow!(source, target, copy(displacement), algorithm)
+    # Sanity checks.
+    @assert size.(axes(source)) == size.(axes(target)) "Images must have the same size"
+    @assert size.(axes(source)) == size.(axes(displacement)) "Optical flow field must match image size"
+    optflow!(source, target, copy(displacement), algorithm)
 end
 
 """
-	flow, indicator  = optical_flow(source, target, points, LucasKanade(Args...))
-	flow, indicator  = optical_flow(source, target, points, displacement, LucasKanade(Args...))
+    flow, indicator  = optical_flow(source, target, points, LucasKanade(Args...))
+    flow, indicator  = optical_flow(source, target, points, displacement, LucasKanade(Args...))
 
 Returns the optical flow from the `source` to the `target` image for the specified `points` using the `LucasKanade` algorithm.
 
@@ -176,18 +179,18 @@ the bounds of the `target` image dimensions.
 
 """
 function optical_flow(source::AbstractArray{T, 2}, target::AbstractArray{T,2}, points::Array{SVector{2, Float64}, 1}, algorithm::LucasKanade) where T <: Gray
-	# Sanity checks.
-	@assert size.(axes(source)) == size.(axes(target)) "Images must have the same size"
+    # Sanity checks.
+    @assert size.(axes(source)) == size.(axes(target)) "Images must have the same size"
 
-	optflow(source, target, points, algorithm)
+    optflow(source, target, points, algorithm)
 end
 
 
 function optical_flow(source::AbstractArray{T, 2}, target::AbstractArray{T,2}, points::Array{SVector{2, Float64}, 1},  displacement::Array{SVector{2, Float64}, 1}, algorithm::LucasKanade) where T <: Gray
-	# sanity checks
-	@assert size.(axes(source)) == size.(axes(target)) "Images must have the same size"
-	@assert size.(axes(points)) == size.(axes(displacement)) "Vector of points and vector of displacement must have the same size"
-	optflow!(source, target, points, copy(displacement), algorithm)
+    # sanity checks
+    @assert size.(axes(source)) == size.(axes(target)) "Images must have the same size"
+    @assert size.(axes(points)) == size.(axes(displacement)) "Vector of points and vector of displacement must have the same size"
+    optflow!(source, target, points, copy(displacement), algorithm)
 end
 
 

--- a/src/optical_flow.jl
+++ b/src/optical_flow.jl
@@ -114,11 +114,11 @@ Default value is `1e-2`.
 1. B. D. Lucas, & Kanade. "An Interative Image Registration Technique with an Application to Stereo Vision," DARPA Image Understanding Workshop, pp 121-130, 1981.
 2. J.-Y. Bouguet, “Pyramidal implementation of the afﬁne lucas-kanade feature tracker description of the algorithm,” Intel Corporation, vol. 5,no. 1-10, p. 4, 2001.
 """
-struct LucasKanade{F <: Float64, I <: Int}  <: OpticalFlowAlgorithm
-    iterations::I
-    window_size::I
-    pyramid_levels::I
-    eigenvalue_threshold::F
+struct LucasKanade <: OpticalFlowAlgorithm
+    iterations::Int
+    window_size::Int
+    pyramid_levels::Int
+    eigenvalue_threshold::Float64
     ϵ::Float64
 end
 

--- a/test/lucas_kanade.jl
+++ b/test/lucas_kanade.jl
@@ -13,7 +13,7 @@ function evaluate_error(dims, flow::Array{SVector{2, Float64}, 1}, Δ, tol)
         if abs(δ[1] - Δ[1]) > tol || abs(δ[2] - Δ[2]) > tol
             error_count += 1
         end
-        error = sqrt((δ[1] - Δ[1]) ^ 2 + (δ[2] - Δ[2]) ^ 2)
+        error = sqrt( (δ[1] - Δ[1])^2 + (δ[2] - Δ[2])^2 )
         if error > maximum_error
             maximum_error = error
         end

--- a/test/lucas_kanade.jl
+++ b/test/lucas_kanade.jl
@@ -2,25 +2,19 @@
 # ten-minute timeout limit on Travis. Travis assumes the tests have hung
 # if the interval between printing something to stdio exceeds ten minutes.
 using Images
-@info "Finished loading Images package."
 using TestImages
-@info "Finished loading TestImages package."
 using StaticArrays
-@info "Finished loading StaticArrays package."
 using OffsetArrays
-@info "Finished loading OffsetArrays package."
 using Random
-@info "Finished loading Random package."
 using CoordinateTransformations
-@info "Finished loading CoordinateTransformations package."
 
-function evaluate_error(dims, flow::Array{SVector{2, Float64}, 1},  Δ,  tol)
+function evaluate_error(dims, flow::Array{SVector{2, Float64}, 1}, Δ, tol)
     error_count = 0
     maximum_error = 0.0
     for i in eachindex(flow)
         δ = flow[i]
         if abs(δ[1] - Δ[1]) > tol || abs(δ[2] - Δ[2]) > tol
-                error_count += 1
+            error_count += 1
         end
         error = sqrt( (δ[1] - Δ[1])^2 + (δ[2] - Δ[2])^2 )
         if error > maximum_error
@@ -36,6 +30,7 @@ end
         maximum_percentage_error = 7.5
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))
+        algorithm = LucasKanade()
 
         tol = 0.3
         Δ = (0.0, 3.0)
@@ -48,20 +43,21 @@ end
         points = map((ri, ci) -> SVector{2}(Float64(ri), Float64(ci)), r, c)
         Random.seed!(9876)
         points = rand(points, (number_test_pts,))
-        flow, status_array = optical_flow(img1, img2, points, LucasKanade(20, 11, 4, 0.000001))
+        flow, status_array = optical_flow(img1, img2, points, algorithm)
 
-        error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
+        error_count, maximum_error = evaluate_error(
+            size(img1), flow[status_array], Δ, tol,
+        )
         percentage_error = (error_count / sum(status_array)) * 100
 
         @info "Case: Horizontal Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
         @test percentage_error  < maximum_percentage_error
 
         # Same as above, except that we pass in an initial displacement field.
-        displacement = Array{SVector{2, Float64}, 1}(undef,length(points))
-        for i in eachindex(displacement)
-                displacement[i] = SVector{2, Float64}(0.0, 0.0)
-        end
-        flow, status_array = optical_flow(img1, img2, points, displacement, LucasKanade(20, 11, 4, 0.000001))
+        displacement = fill(SVector{2, Float64}(0.0, 0.0), length(points))
+        flow, status_array = optical_flow(
+            img1, img2, points, displacement, algorithm,
+        )
 
         error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
         percentage_error = (error_count / sum(status_array)) * 100
@@ -75,6 +71,7 @@ end
         maximum_percentage_error = 7.5
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))
+        algorithm = LucasKanade()
 
         tol = 0.3
         Δ = (3.0, 0.0)
@@ -87,7 +84,7 @@ end
         points = map((ri, ci) -> SVector{2}(Float64(ri), Float64(ci)), r, c)
         Random.seed!(9876)
         points = rand(points, (number_test_pts,))
-        flow, status_array = optical_flow(img1, img2, points, LucasKanade(20, 11, 4, 0.000001))
+        flow, status_array = optical_flow(img1, img2, points, algorithm)
 
         error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
         percentage_error = (error_count / sum(status_array)) * 100
@@ -96,11 +93,10 @@ end
         @test percentage_error  < maximum_percentage_error
 
         # Same as above, except that we pass in an initial displacement field.
-        displacement = Array{SVector{2, Float64}, 1}(undef,length(points))
-        for i in eachindex(displacement)
-                displacement[i] = SVector{2, Float64}(0.0, 0.0)
-        end
-        flow, status_array = optical_flow(img1, img2, points, displacement, LucasKanade(20, 11, 4, 0.000001))
+        displacement = fill(SVector{2, Float64}(0.0, 0.0), length(points))
+        flow, status_array = optical_flow(
+            img1, img2, points, displacement, algorithm,
+        )
 
         error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
         percentage_error = (error_count / sum(status_array)) * 100
@@ -114,6 +110,7 @@ end
         maximum_percentage_error = 13
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))
+        algorithm = LucasKanade()
 
         tol = 0.3
         Δ = (3.0, -1.0)
@@ -126,26 +123,28 @@ end
         points = map((ri, ci) -> SVector{2}(Float64(ri), Float64(ci)), r, c)
         Random.seed!(9876)
         points = rand(points, (number_test_pts,))
-        flow, status_array = optical_flow(img1, img2, points, LucasKanade(20, 11, 4, 0.000001))
+        flow, status_array = optical_flow(img1, img2, points, algorithm)
 
-        error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
+        error_count, maximum_error = evaluate_error(
+            size(img1), flow[status_array], Δ, tol,
+        )
         percentage_error = (error_count / sum(status_array)) * 100
 
         @info "Case: Combined Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
-        @test percentage_error  < maximum_percentage_error
+        @test percentage_error < maximum_percentage_error
 
         # Same as above, except that we pass in an initial displacement field.
-        displacement = Array{SVector{2, Float64}, 1}(undef,length(points))
-        for i in eachindex(displacement)
-                displacement[i] = SVector{2, Float64}(0.0, 0.0)
-        end
-        flow, status_array = optical_flow(img1, img2, points, displacement, LucasKanade(20, 11, 4, 0.000001))
+        displacement = fill(SVector{2, Float64}(0.0, 0.0), length(points))
+        flow, status_array = optical_flow(
+            img1, img2, points, displacement, algorithm,
+        )
 
-        error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
+        error_count, maximum_error = evaluate_error(
+            size(img1), flow[status_array], Δ, tol,
+        )
         percentage_error = (error_count / sum(status_array)) * 100
 
         @info "Case: Combined Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
-        @test percentage_error  < maximum_percentage_error
+        @test percentage_error < maximum_percentage_error
     end
-
-end;
+end

--- a/test/lucas_kanade.jl
+++ b/test/lucas_kanade.jl
@@ -34,7 +34,7 @@ end
         @info "Running Horizontal Motion test."
         Random.seed!(9876)
 
-        tol = 1e-2
+        tol = 1e-1
         maximum_percentage_error = 7
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))
@@ -65,7 +65,7 @@ end
         @info "Running Vertical Motion test."
         Random.seed!(9876)
 
-        tol = 1e-2
+        tol = 1e-1
         maximum_percentage_error = 7
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))
@@ -96,7 +96,7 @@ end
         @info "Running Combined Motion test."
         Random.seed!(9876)
 
-        tol = 1e-2
+        tol = 1e-1
         maximum_percentage_error = 7
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))

--- a/test/lucas_kanade.jl
+++ b/test/lucas_kanade.jl
@@ -23,7 +23,7 @@ end
 
 function get_keypoints(image, n_points)
     corners = imcorner(image, method=shi_tomasi)
-    I = findall(!iszero, corners)
+    I = CartesianIndices(corners)[corners .!= 0]
     r, c = (getindex.(I, 1), getindex.(I, 2))
     points = map((ri, ci) -> SVector{2, Float64}(ri, ci), r, c)
     rand(points, n_points)

--- a/test/lucas_kanade.jl
+++ b/test/lucas_kanade.jl
@@ -1,6 +1,3 @@
-# We output a message after loading each package to work around a
-# ten-minute timeout limit on Travis. Travis assumes the tests have hung
-# if the interval between printing something to stdio exceeds ten minutes.
 using Images
 using TestImages
 using StaticArrays
@@ -16,7 +13,7 @@ function evaluate_error(dims, flow::Array{SVector{2, Float64}, 1}, Δ, tol)
         if abs(δ[1] - Δ[1]) > tol || abs(δ[2] - Δ[2]) > tol
             error_count += 1
         end
-        error = sqrt( (δ[1] - Δ[1])^2 + (δ[2] - Δ[2])^2 )
+        error = sqrt((δ[1] - Δ[1]) ^ 2 + (δ[2] - Δ[2]) ^ 2)
         if error > maximum_error
             maximum_error = error
         end
@@ -24,126 +21,104 @@ function evaluate_error(dims, flow::Array{SVector{2, Float64}, 1}, Δ, tol)
     return error_count, maximum_error
 end
 
+function get_keypoints(image, n_points)
+    corners = imcorner(image, method=shi_tomasi)
+    I = findall(!iszero, corners)
+    r, c = (getindex.(I, 1), getindex.(I, 2))
+    points = map((ri, ci) -> SVector{2, Float64}(ri, ci), r, c)
+    rand(points, n_points)
+end
+
 @testset "Lucas-Kanade" begin
     @testset "Horizontal Motion" begin
         @info "Running Horizontal Motion test."
-        maximum_percentage_error = 7.5
+        Random.seed!(9876)
+
+        tol = 1e-2
+        maximum_percentage_error = 7
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))
         algorithm = LucasKanade()
 
-        tol = 0.3
         Δ = (0.0, 3.0)
         trans = Translation(-Δ[1], -Δ[2])
         img2 = warp(img1, trans, axes(img1))
 
-        corners = imcorner(img1, method=shi_tomasi)
-        I = findall(!iszero, corners)
-        r, c = (getindex.(I, 1), getindex.(I, 2))
-        points = map((ri, ci) -> SVector{2}(Float64(ri), Float64(ci)), r, c)
-        Random.seed!(9876)
-        points = rand(points, (number_test_pts,))
-        flow, status_array = optical_flow(img1, img2, points, algorithm)
+        points = get_keypoints(img1, number_test_pts)
 
-        error_count, maximum_error = evaluate_error(
-            size(img1), flow[status_array], Δ, tol,
-        )
-        percentage_error = (error_count / sum(status_array)) * 100
-
+        flow, status = optical_flow(img1, img2, points, algorithm)
+        error_count, maximum_error = evaluate_error(size(img1), flow[status], Δ, tol)
+        percentage_error = (error_count / sum(status)) * 100
         @info "Case: Horizontal Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
-        @test percentage_error  < maximum_percentage_error
+        @test percentage_error < maximum_percentage_error
 
         # Same as above, except that we pass in an initial displacement field.
         displacement = fill(SVector{2, Float64}(0.0, 0.0), length(points))
-        flow, status_array = optical_flow(
-            img1, img2, points, displacement, algorithm,
-        )
-
-        error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
-        percentage_error = (error_count / sum(status_array)) * 100
-
+        flow, status = optical_flow(img1, img2, points, displacement, algorithm)
+        error_count, maximum_error = evaluate_error(size(img1), flow[status], Δ, tol)
+        percentage_error = (error_count / sum(status)) * 100
         @info "Case: Horizontal Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
-        @test percentage_error  < maximum_percentage_error
+        @test percentage_error < maximum_percentage_error
     end
 
     @testset "Vertical Motion" begin
         @info "Running Vertical Motion test."
-        maximum_percentage_error = 7.5
+        Random.seed!(9876)
+
+        tol = 1e-2
+        maximum_percentage_error = 7
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))
         algorithm = LucasKanade()
 
-        tol = 0.3
         Δ = (3.0, 0.0)
         trans = Translation(-Δ[1], -Δ[2])
         img2 = warp(img1, trans, axes(img1))
 
-        corners = imcorner(img1, method=shi_tomasi)
-        I = findall(!iszero, corners)
-        r, c = (getindex.(I, 1), getindex.(I, 2))
-        points = map((ri, ci) -> SVector{2}(Float64(ri), Float64(ci)), r, c)
-        Random.seed!(9876)
-        points = rand(points, (number_test_pts,))
-        flow, status_array = optical_flow(img1, img2, points, algorithm)
+        points = get_keypoints(img1, number_test_pts)
 
+        flow, status_array = optical_flow(img1, img2, points, algorithm)
         error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
         percentage_error = (error_count / sum(status_array)) * 100
-
         @info "Case: Vertical Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
-        @test percentage_error  < maximum_percentage_error
+        @test percentage_error < maximum_percentage_error
 
         # Same as above, except that we pass in an initial displacement field.
         displacement = fill(SVector{2, Float64}(0.0, 0.0), length(points))
-        flow, status_array = optical_flow(
-            img1, img2, points, displacement, algorithm,
-        )
-
+        flow, status_array = optical_flow(img1, img2, points, displacement, algorithm)
         error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
         percentage_error = (error_count / sum(status_array)) * 100
-
         @info "Case: Vertical Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
-        @test percentage_error  < maximum_percentage_error
+        @test percentage_error < maximum_percentage_error
     end
 
     @testset "Combined Motion" begin
         @info "Running Combined Motion test."
-        maximum_percentage_error = 13
+        Random.seed!(9876)
+
+        tol = 1e-2
+        maximum_percentage_error = 7
         number_test_pts = 500
         img1 = Gray{Float64}.(testimage("mandrill"))
         algorithm = LucasKanade()
 
-        tol = 0.3
         Δ = (3.0, -1.0)
         trans = Translation(-Δ[1], -Δ[2])
         img2 = warp(img1, trans, axes(img1))
 
-        corners = imcorner(img1, method=shi_tomasi)
-        I = findall(!iszero, corners)
-        r, c = (getindex.(I, 1), getindex.(I, 2))
-        points = map((ri, ci) -> SVector{2}(Float64(ri), Float64(ci)), r, c)
-        Random.seed!(9876)
-        points = rand(points, (number_test_pts,))
+        points = get_keypoints(img1, number_test_pts)
+
         flow, status_array = optical_flow(img1, img2, points, algorithm)
-
-        error_count, maximum_error = evaluate_error(
-            size(img1), flow[status_array], Δ, tol,
-        )
+        error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
         percentage_error = (error_count / sum(status_array)) * 100
-
         @info "Case: Combined Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
         @test percentage_error < maximum_percentage_error
 
         # Same as above, except that we pass in an initial displacement field.
         displacement = fill(SVector{2, Float64}(0.0, 0.0), length(points))
-        flow, status_array = optical_flow(
-            img1, img2, points, displacement, algorithm,
-        )
-
-        error_count, maximum_error = evaluate_error(
-            size(img1), flow[status_array], Δ, tol,
-        )
+        flow, status_array = optical_flow(img1, img2, points, displacement, algorithm)
+        error_count, maximum_error = evaluate_error(size(img1), flow[status_array], Δ, tol)
         percentage_error = (error_count / sum(status_array)) * 100
-
         @info "Case: Combined Motion", "Percentage Error: $(percentage_error)", "Maximum Error: $(maximum_error)"
         @test percentage_error < maximum_percentage_error
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using ImageTracking
 using Test
 
-
 include("farneback.jl")
 include("lucas_kanade.jl")
 include("haar.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,3 @@ include("lucas_kanade.jl")
 include("haar.jl")
 include("visualization.jl")
 include("error_evaluation.jl")
-


### PR DESCRIPTION
Hi! I was trying to use LK optical flow and noticed that it didn't give the correct results.
Either the flow was too big or its direction was incorrect. Additionally it was dropping a lot of points, marking them as bad.

#### Bugs:

Upon investigation I've noticed two major bugs:

1. Incorrect pyramid level in the `determine_pyramid_coordinates` function.
    The indexing starts at `1`, but when computing pyramid point, it should start at `0`, so the first level does not change the coordinates, since it is the original level.
2. In the beginning of the optical flow there is the conversion of points and initial displacements from `(row, col)` to `(x, y)` format.
    However, all subsequent functions operate in the `(row, col)` format.
    Simple way to check this is to visualize the gradient windows for the points.

#### Changes:

Do tell me if you don't agree with some of the changes.

- Use the correct index for pyramid level.
- Drop the conversion from `(row, col)` to `(x, y)` and operate only in `(row, col)` format.
- Set default value for the `eigenvalue_threshold` parameter to `1e-4` as in [OpenCV](https://docs.opencv.org/4.5.2/dc/d6b/group__video__track.html#ga473e4b886d0bcc6b65831eb88ed93323).
- Remove `in_image` function, since `lies_in` is enough.
- Convert `while` loops to explicit expressions in `get_grid` function.
- Simplify displacement creation in tests.
- Use default parameters in tests for Lucas-Kanade algorithm.
- Refactoring.
  Replace tabs in certain places with spaces for consistency purposes.
  Make rows no more than 92 characters long & minor refactoring (this allows for split-screen editing 🙃).
- Add epsilon termination criteria as in [OpenCV LK](https://docs.opencv.org/4.5.2/d9/d5d/classcv_1_1TermCriteria.html#a56fecdc291ccaba8aad27d67ccf72c57a857609e73e7028e638d2ea649f3b45d5).
- Update LK tests to require bigger accuracy.
- Remove `is_truncated_window`. Use `get_grid` to determine whether we need to recompute gradient or can use the previous one.
- Remove `flow` vector, since it was used only to store pyramid layer contributions and was redundant.
- Remove extrapolation and use only interpolation for the second pyramid layers.
  Since we never operate on the out-of-bounds regions.
- Use svd2x2 to compute minimum eigenvalues instead of calling `eigen`.
- Make `optflow!` function operate on the `LKPyramid` structure that holds image pyramid and gradients.

#### TODOs:
- [ ] Add ability to pass precomputed pyramids and image gradients.
      This can be useful, when computing flow for the image with more than one other image.
      Since this way we would need to compute them only once.
      I think about either adding them to keyword parameters, or creating `LKPyramid` struct that will contain both pyramids and gradients. Creating struct will decrease number of parameters in the function, which would make things easier.

#### Visual comparison:

I've used the same code for visualization as in the example docs.

Starting with the simple case, where the figure moves only horizontally.

|Current|This PR|
|:-:|:-:|
|![lk-old-1](https://user-images.githubusercontent.com/17990405/124880432-f4eb7880-dfd6-11eb-8a7f-5fe88122371a.png)|![lk-new-1](https://user-images.githubusercontent.com/17990405/124880455-f9b02c80-dfd6-11eb-8d02-8015fb5e6afb.png)|

Car moves forward. Two adjacent frames in a video.

|Current|This PR|
|:-:|:-:|
|![lk-old-3](https://user-images.githubusercontent.com/17990405/124880624-2b28f800-dfd7-11eb-9c4b-8dafa97bed83.png)|![lk-new-3](https://user-images.githubusercontent.com/17990405/125197376-0ac29d00-e266-11eb-9153-911ec6757174.png)|

Basketball example. Motion is mainly in the hands and the body. Static background.

|Current|This PR|
|:-:|:-:|
|![lk-old-4](https://user-images.githubusercontent.com/17990405/124880847-61667780-dfd7-11eb-9e55-37676d1c9788.png)|![lk-new-4](https://user-images.githubusercontent.com/17990405/125197394-17df8c00-e266-11eb-8d77-b64f6fcb07b3.png)|

Cup. Horizontal movement.

|Current|This PR|
|:-:|:-:|
|![lk-old-2](https://user-images.githubusercontent.com/17990405/124881324-dfc31980-dfd7-11eb-83bb-2f4bc863afea.png)|![lk-new-2](https://user-images.githubusercontent.com/17990405/125197415-27f76b80-e266-11eb-9c4e-1cf7a8212e98.png)|