### PR TITLE
update CI settings and dependency compat versions

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,16 +1,25 @@
 name: CompatHelper
-
 on:
   schedule:
-    - cron: '00 00 * * *'
-
+    - cron: 0 0 * * *
+  workflow_dispatch:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "2"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+          COMPATHELPER_PRIV: ${{ secrets.TAGBOT }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,12 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
 
 jobs:
   test:
@@ -17,14 +15,23 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.0', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
+        arch: [x64]
+        include:
+          - os: windows-latest
+            julia-version: '1'
+            arch: x64
+          - os: macOS-latest
+            julia-version: '1'
+            arch: x64
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.arch }}
 
       - name: Cache artifacts
         uses: actions/cache@v1
@@ -37,7 +44,6 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-
       - name: "Unit Test"
         uses: julia-actions/julia-runtest@master
 

--- a/Project.toml
+++ b/Project.toml
@@ -12,12 +12,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-AxisAlgorithms = "1"
+AxisAlgorithms = "0.3, 1"
 CoordinateTransformations = "0.5, 0.6"
 Images = "0.18, 0.19, 0.20, 0.21, 0.22, 0.23"
-Interpolations = "0.10, 0.11, 0.12"
-StaticArrays = "0.10, 0.11, 0.12"
-julia = "1.0"
+Interpolations = "0.10, 0.11, 0.12, 0.13"
+StaticArrays = "0.10, 0.11, 0.12, 1"
+julia = "1"
 
 [extras]
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"

--- a/src/lucas_kanade.jl
+++ b/src/lucas_kanade.jl
@@ -249,7 +249,8 @@ function get_offsets(point, new_point, window, image_axes)
     (-up:down, -left:right)
 end
 
-@inline get_grid(point, offsets) = @inbounds (
-    (point[1] + offsets[1][begin]):(point[1] + offsets[1][end]),
-    (point[2] + offsets[2][begin]):(point[2] + offsets[2][end]),
-)
+function get_grid(point, offsets)
+    map(point, offsets) do p, o
+        p+first(o):p+last(o)
+    end
+end


### PR DESCRIPTION
Just realize that CI is automatically disabled in this repo because of the inactivity. Let's see if the fantastic PR #34 provided by @pxl-th passes the CI.

- scheduled github actions will now automatically get disabled after
  30(or 60) days inactivity so here we remove the schedule task for
  our unit test.
- macos and windows CI resources are more limited so here I restrict
  it to only Julia 1.x version
- upgrade TagBot and CompatHelper configurations wrt their documentation (closes #31, closes #32)

This PR also updates the dependency versions (closes #29, closes #30)